### PR TITLE
Return error code for migration check

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -13,6 +13,7 @@ export function runChildProc(command: string, args: string[]) {
     throw proc.error
   }
   console.info(`child process  exited with code ${proc.status}`)
+  return proc.status
 }
 
 const prompter = prompt()

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,8 +54,7 @@ async function run(command: commands): Promise<number> {
       createMigration(process.argv[3])
       return 0
     case 'migration-check':
-      checkMigration()
-      return 0
+      return checkMigration() ?? 0
     case 'migration-revert':
       revertMigration()
       return 0
@@ -219,7 +218,7 @@ function createMigration(name: string) {
 function checkMigration() {
   writeText(`Checking if migration is needed`)
 
-  runChildProc('typeorm-ts-node-commonjs', [
+  return runChildProc('typeorm-ts-node-commonjs', [
     `migration:generate`,
     '--dryrun',
     '--dataSource',


### PR DESCRIPTION
When using the toolkit in a CI pipeline we tend to run a migration and then run the migration check. This ensures that we haven't forgotten to create a migration when code changes are made that require a structural change in the DB.

Currently the check detects the required changes but doesn't return an error code, so the CI pipeline continues when it should fail.